### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.12.0a4-alpine
 
 COPY requirements.txt /
 


### PR DESCRIPTION
Title: Upgrade base image from python:3.6-alpine to python:3.12.0a4-alpine

Description:
This pull request proposes upgrading the base image in the Dockerfile from `python:3.6-alpine` to `python:3.12.0a4-alpine` to take advantage of the new features and security updates provided by the latest version of Python.

Steps to reproduce:
- Replace the current line `FROM python:3.6-alpine` with `FROM python:3.12.0a4-alpine` in the Dockerfile.

Benefits:
- The latest version of Python provides new features, improved performance, and security updates.
- Upgrading the base image helps to ensure that our application runs on a stable and secure environment.

Risks:
- There is a possibility that the upgrade may introduce compatibility issues with the existing dependencies or code.
- As this is an alpha release, it may have bugs and other issues that have not yet been discovered.

Checklist:
- [X] Replace the current line `FROM python:3.6-alpine` with `FROM python:3.12.0a4-alpine` in the Dockerfile.
- [ ] Run the test suite to ensure compatibility with the new base image.
- [ ] Update the documentation to reflect the change in the base image.